### PR TITLE
Update jDMq-RaYFpA.md

### DIFF
--- a/errata/jDMq-RaYFpA.md
+++ b/errata/jDMq-RaYFpA.md
@@ -37,7 +37,7 @@ For full instructions see [README](../../..#readme)
 
 
 3:00 ------------------------------------------------  
-
+3:03 "But you got to realize that the amount of ~~volts~~ **current** that actually flows through the indicator is in the ~~millivolt~~ **milliamp** range. It's not enough to light up a lamp, a circuit, not enough to turn on a motor. Another thing you got to realize is that a neon bulb changes the waveform of the current going through it. The neon bulb only ignites when the ~~current~~ **voltage** is at its peaks, whether that be peaking positive or negative."
 
 
 

--- a/errata/jDMq-RaYFpA.md
+++ b/errata/jDMq-RaYFpA.md
@@ -37,7 +37,9 @@ For full instructions see [README](../../..#readme)
 
 
 3:00 ------------------------------------------------  
-3:03 "But you got to realize that the amount of ~~volts~~ **current** that actually flows through the indicator is in the ~~millivolt~~ **milliamp** range. It's not enough to light up a lamp, a circuit, not enough to turn on a motor. Another thing you got to realize is that a neon bulb changes the waveform of the current going through it. The neon bulb only ignites when the ~~current~~ **voltage** is at its peaks, whether that be peaking positive or negative."
+3:03 "But you got to realize that the amount of ~~volts~~ **current** that actually flows through the indicator is in the ~~millivolt~~ **milliamp** range."
+
+3:25 "The neon bulb only ignites when the ~~current~~ **voltage** is at its peaks, whether that be peaking positive or negative."
 
 
 


### PR DESCRIPTION
current and voltage were swapped when discussing the  neon bulb in a blown fuse indicator.

<!--
Thank you for contributing to this YouRata project! Errata submissions should contain at least: The time in the video the mistake was made, a summary of the erroneous statement, the corrected statement as it pertains to the YouTube video, and any independent knowledge sources.
-->


<!--
References can be book titles, visual evidence, witness statements, etc. You can drag and drop file attachments directly to this section.
-->
